### PR TITLE
Update add_team function

### DIFF
--- a/R/team_managment.R
+++ b/R/team_managment.R
@@ -32,10 +32,11 @@ activate_team <- function(team, verbose = TRUE) {
 
 #' @rdname manage_team
 #' @export
-add_team <- function(team, memberid, key) {
-  new_team <- list(memberid = memberid, key = key)
+add_team <- function(team, key, memberid){
+  new_team <- list(team = list(memberid = memberid, key = key))
   names(new_team) <- team
-  .slack$teams <- append(.slack$teams, new_team)
+  .slack$teams <- append(.slack$teams, team)
+  .slack$file <- append(.slack$file,new_team)
 }
 
 

--- a/R/team_managment.R
+++ b/R/team_managment.R
@@ -32,7 +32,7 @@ activate_team <- function(team, verbose = TRUE) {
 
 #' @rdname manage_team
 #' @export
-add_team <- function(team, key, memberid){
+add_team <- function(team, memberid, key){
   new_team <- list(team = list(memberid = memberid, key = key))
   names(new_team) <- team
   .slack$teams <- append(.slack$teams, team)


### PR DESCRIPTION
The naming of the list named the first element rather than the list itself.

``` r
slackteams::add_team("myteam", "bob", "12345")

slackteams::load_teams()
#> The following teams are loaded:
#>   myteam, NA
```

<sup>Created on 2020-03-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
